### PR TITLE
Changes to `apply-value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   - `:multi-value?`: If provided, then `value` must be a collection of values that will be applied in order. Returns the modified `json` once `value` or the available path seqs runs out.
   - `:wildcard-append?`: Dictates if wildcard values should be appended to the end of existing seqs. Default `true`.
   - `:wildcard-limit`: Dictates how many wildcard paths should be generated. Default `1`.
+- Add a `speculate-paths` function that acts like `get-paths` but is not stopped by missing values. Also accepts `:wildcard-append?` and `:wildcard-limit` opt args.
+
 ## 0.4.1 - 2022-10-24
 - Update GitHub CI and CD to remove deprecation warnings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.4.2 - 2023-05-29
+- Update the `apply-value` function to support the following optional args:
+  - `:multi-value?`: If provided, then `value` must be a collection of values that will be applied in order. Returns the modified `json` once `value` or the available path seqs runs out.
+  - `:wildcard-append?`: Dictates if wildcard values should be appended to the end of existing seqs. Default `true`.
+  - `:wildcard-limit`: Dictates how many wildcard paths should be generated. Default `1`.
 ## 0.4.1 - 2022-10-24
 - Update GitHub CI and CD to remove deprecation warnings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 
-## 0.4.2 - 2023-05-29
+## 0.5.0 - 2023-06-27
 - Update the `apply-value` function to support the following optional args:
-  - `:multi-value?`: If provided, then `value` must be a collection of values that will be applied in order. Returns the modified `json` once `value` or the available path seqs runs out.
-  - `:wildcard-append?`: Dictates if wildcard values should be appended to the end of existing seqs. Default `true`.
-  - `:wildcard-limit`: Dictates how many wildcard paths should be generated. Default `1`.
+  - `:wildcard-append?`: Dictates if wildcard values should be appended to the end of existing seqs. Default `false`. (_NOTE:_ The new default constitutes a breaking change!)
+  - `:wildcard-limit`: Dictates how many wildcard paths should be generated. If it is not present then the entire coll gets overwritten at each wildcard location if `wildcard-append?` is `false`; if it's `true`, 1 new path gets appended.
+  - Change the
+- Add a `apply-multi-value` that is similar to `apply-value`, except that it must accept a collection of `values` that will be applied in order. Returns the modified `json` once `values` or the available path seqs runs out. Also accepts `:wildcard-append?` and `wildcard-limit`.
 - Add a `speculate-paths` function that acts like `get-paths` but is not stopped by missing values. Also accepts `:wildcard-append?` and `:wildcard-limit` opt args.
+- Add `wildcard-append` and `wildcard-limit` args to `json-path/speculate-path-seqs`.
 
 ## 0.4.1 - 2022-10-24
 - Update GitHub CI and CD to remove deprecation warnings.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden 
 
 :wildcard-append? Dictates if wildcard values should be appended to
                   the end of existing seqs instead of overwriting existing
-                  values. Default `true`.
+                  values. Default `false`.
 :wildcard-limit   Dictates how many wildcard paths should be generated.
                   In overwrite mode, defaults to the length of each coll.
                   In append mode, defaults to 1.
@@ -257,7 +257,7 @@ Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden 
                   seqs runs out.
 :wildcard-append? Dictates if wildcard values should be appended to
                   the end of existing seqs instead of overwriting existing
-                  values. Default `true`.
+                  values. Default `false`.
 :wildcard-limit   Dictates how many wildcard paths should be generated.
                   If `multi-value?`, defaults to the number of values.
                   In overwrite mode, defaults to the length of each coll.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,18 @@ The following caveats apply:
 - Recursive descent, array slicing, and negative array indices
   are disallowed (as per strict mode).
 
-Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`.
+Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
+
+:multi-value?      If provided, then `value` must be a collection of
+                   values that will be applied in order, e.g. for an
+                   array specified by `[0,1]` in the path, then the first
+                   and second elements of `value` will be applied. Supports
+                   potentially-infinite lazy seqs. Returns the modified
+                   `json` once `value` or the available path seqs runs out.
+:wildcard-append? Dictates if wildcard values should be appended to
+                  the end of existing seqs. Default `true`.
+:wildcard-limit   Dictates how many wildcard paths should be generated   
+                  Default `1`.
 ```
 
 ``` clojure

--- a/README.md
+++ b/README.md
@@ -106,45 +106,6 @@ Supports :first?, :strict?, and :return-missing? in `opts-map`.
 => [["context" "contextActivities" "grouping"]]
 ```
 
-### speculate-paths
-
-```
-Given `json` and a JSONPath string `paths`, return a vector of
-definite key paths, just like `get-paths`. However, unlike `get-paths`,
-paths will be enumerated even if the corresponding value does not exist
-in `json` on that path; in other words, it speculates what paths would
-exist if they are applied. If the string contains multiple JSONPaths, we
-return the key paths for all strings.
-
-Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
-
-:wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs instead of overwriting existing
-                  values. Default `false`.
-:wildcard-limit   Dictates how many wildcard paths should be generated.
-                  In overwrite mode, defaults to the length of each coll.
-                  In append mode, defaults to 1.
-```
-
-```clojure
-(speculate-paths stmt "$.context.contextActivities.grouping[*]")
-=> [["context" "contextActivities" "grouping" 0]]
-
-(speculate-paths stmt "$.context.contextActivities.category[*].id")
-=> [["context" "contextActivities" "category" 1 "id"]]
-
-(speculate-paths stmt
-                 "$.context.contextActivities.category[*].id" 
-                 {:wildcard-limit 2})
-=> [["context" "contextActivities" "category" 1 "id"]
-    ["context" "contextActivities" "category" 2 "id"]]
-
-(speculate-paths stmt
-                 "$.context.contextActivities.category[*].id" 
-                 {:wildcard-append? false})
-=> [["context" "contextActivities" "category" 0 "id"]]
-```
-
 ### get-values
 
 ```
@@ -224,6 +185,45 @@ Supports :first?, :strict?, and :prune-empty? in `opts-map`.
 ``` clojure
 (= (dissoc stmt "id")
    (excise stmt "$.id"))
+```
+
+### speculate-paths
+
+```
+Given `json` and a JSONPath string `paths`, return a vector of
+definite key paths, just like `get-paths`. However, unlike `get-paths`,
+paths will be enumerated even if the corresponding value does not exist
+in `json` on that path; in other words, it speculates what paths would
+exist if they are applied. If the string contains multiple JSONPaths, we
+return the key paths for all strings.
+
+Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
+
+:wildcard-append? Dictates if wildcard values should be appended to
+                  the end of existing seqs instead of overwriting existing
+                  values. Default `false`.
+:wildcard-limit   Dictates how many wildcard paths should be generated.
+                  In overwrite mode, defaults to the length of each coll.
+                  In append mode, defaults to 1.
+```
+
+```clojure
+(speculate-paths stmt "$.context.contextActivities.grouping[*]")
+=> [["context" "contextActivities" "grouping" 0]]
+
+(speculate-paths stmt "$.context.contextActivities.category[*].id")
+=> [["context" "contextActivities" "category" 1 "id"]]
+
+(speculate-paths stmt
+                 "$.context.contextActivities.category[*].id" 
+                 {:wildcard-limit 2})
+=> [["context" "contextActivities" "category" 1 "id"]
+    ["context" "contextActivities" "category" 2 "id"]]
+
+(speculate-paths stmt
+                 "$.context.contextActivities.category[*].id" 
+                 {:wildcard-append? false})
+=> [["context" "contextActivities" "category" 0 "id"]]
 ```
 
 ### apply-value

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ return the key paths for all strings.
 Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
 
 :wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs. Default `true`.
+                  the end of existing seqs instead of overwriting existing
+                  values. Default `true`.
 :wildcard-limit   Dictates how many wildcard paths should be generated.
-                  Default `1`.
+                  In overwrite mode, defaults to the length of each coll.
+                  In append mode, defaults to 1.
 ```
 
 ```clojure
@@ -254,9 +256,12 @@ Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden 
                   the modified `json` once `value` or the available path
                   seqs runs out.
 :wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs. Default `true`.
-:wildcard-limit   Dictates how many wildcard paths should be generated   
-                  Default `1`.
+                  the end of existing seqs instead of overwriting existing
+                  values. Default `true`.
+:wildcard-limit   Dictates how many wildcard paths should be generated.
+                  If `multi-value?`, defaults to the number of values.
+                  In overwrite mode, defaults to the length of each coll.
+                  In append mode, defaults to 1.
 ```
 
 ``` clojure

--- a/README.md
+++ b/README.md
@@ -110,19 +110,18 @@ Supports :first?, :strict?, and :return-missing? in `opts-map`.
 
 ```
 Given `json` and a JSONPath string `paths`, return a vector of
-   definite key paths, just like `get-paths`. However, unlike `get-paths`,
-   paths will be enumerated even if the corresponding value does not exist
-   in `json` on that path; in other words, it speculates what paths would
-   exist if they are applied. If the string contains multiple JSONPaths, we
-   return the key paths for all strings.
-   
-   The following `opts-map` fields are supported:
-     :first?           Only apply the first \"|\"-separated path.
-     :strict?          Always set to `true`.
-     :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs. Default `true`.
-     :wildcard-limit   Dictates how many wildcard paths should be generated.
-                       Default `1`.
+definite key paths, just like `get-paths`. However, unlike `get-paths`,
+paths will be enumerated even if the corresponding value does not exist
+in `json` on that path; in other words, it speculates what paths would
+exist if they are applied. If the string contains multiple JSONPaths, we
+return the key paths for all strings.
+
+Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
+
+:wildcard-append? Dictates if wildcard values should be appended to
+                  the end of existing seqs. Default `true`.
+:wildcard-limit   Dictates how many wildcard paths should be generated.
+                  Default `1`.
 ```
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Utility Library for working with [JSON Path](https://goessner.net/articles/JsonP
 Add the following to your `:deps` map in your deps.edn file:
 
 ```clojure
-com.yetanalytics/pathetic {:mvn/version "0.4.1"
+com.yetanalytics/pathetic {:mvn/version "0.4.2"
                            :exclusions [org.clojure/clojure
                                         org.clojure/clojurescript]}
 ```

--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ The following caveats apply:
 
 Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
 
-:multi-value?      If provided, then `value` must be a collection of
-                   values that will be applied in order, e.g. for an
-                   array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Returns
-                   the modified `json` once `value` or the available path
-                   seqs runs out.
+:multi-value?     If provided, then `value` must be a collection of
+                  values that will be applied in order, e.g. for an
+                  array specified by `[0,1]` in the path, then the first
+                  and second elements of `value` will be applied. Returns
+                  the modified `json` once `value` or the available path
+                  seqs runs out.
 :wildcard-append? Dictates if wildcard values should be appended to
                   the end of existing seqs. Default `true`.
 :wildcard-limit   Dictates how many wildcard paths should be generated   

--- a/README.md
+++ b/README.md
@@ -106,6 +106,44 @@ Supports :first?, :strict?, and :return-missing? in `opts-map`.
 => [["context" "contextActivities" "grouping"]]
 ```
 
+### speculate-paths
+
+```
+Given `json` and a JSONPath string `paths`, return a vector of
+   definite key paths, just like `get-paths`. However, unlike `get-paths`,
+   paths will be enumerated even if the corresponding value does not exist
+   in `json` on that path; in other words, it speculates what paths would
+   exist if they are applied. If the string contains multiple JSONPaths, we
+   return the key paths for all strings.
+   
+   The following `opts-map` fields are supported:
+     :first?           Only apply the first \"|\"-separated path.
+     :strict?          Always set to `true`.
+     :wildcard-append? Dictates if wildcard values should be appended to
+                       the end of existing seqs. Default `true`.
+     :wildcard-limit   Dictates how many wildcard paths should be generated.
+                       Default `1`.
+```
+
+```clojure
+(speculate-paths stmt "$.context.contextActivities.grouping[*]")
+=> [["context" "contextActivities" "grouping" 0]]
+
+(speculate-paths stmt "$.context.contextActivities.category[*].id")
+=> [["context" "contextActivities" "category" 1 "id"]]
+
+(speculate-paths stmt
+                 "$.context.contextActivities.category[*].id" 
+                 {:wildcard-limit 2})
+=> [["context" "contextActivities" "category" 1 "id"]
+    ["context" "contextActivities" "category" 2 "id"]]
+
+(speculate-paths stmt
+                 "$.context.contextActivities.category[*].id" 
+                 {:wildcard-append? false})
+=> [["context" "contextActivities" "category" 0 "id"]]
+```
+
 ### get-values
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Utility Library for working with [JSON Path](https://goessner.net/articles/JsonP
 Add the following to your `:deps` map in your deps.edn file:
 
 ```clojure
-com.yetanalytics/pathetic {:mvn/version "0.4.2"
+com.yetanalytics/pathetic {:mvn/version "0.5.0"
                            :exclusions [org.clojure/clojure
                                         org.clojure/clojurescript]}
 ```

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden 
 :multi-value?      If provided, then `value` must be a collection of
                    values that will be applied in order, e.g. for an
                    array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Supports
-                   potentially-infinite lazy seqs. Returns the modified
-                   `json` once `value` or the available path seqs runs out.
+                   and second elements of `value` will be applied. Returns
+                   the modified `json` once `value` or the available path
+                   seqs runs out.
 :wildcard-append? Dictates if wildcard values should be appended to
                   the end of existing seqs. Default `true`.
 :wildcard-limit   Dictates how many wildcard paths should be generated   

--- a/README.md
+++ b/README.md
@@ -197,14 +197,7 @@ in `json` on that path; in other words, it speculates what paths would
 exist if they are applied. If the string contains multiple JSONPaths, we
 return the key paths for all strings.
 
-Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
-
-:wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs instead of overwriting existing
-                  values. Default `false`.
-:wildcard-limit   Dictates how many wildcard paths should be generated.
-                  In overwrite mode, defaults to the length of each coll.
-                  In append mode, defaults to 1.
+Supports :first? in `opts-map`; :strict? is always overridden to `true`. Also accepts :wildcard-append? and :wildcard-limit args to affect behavior on wildcards.
 ```
 
 ```clojure
@@ -234,34 +227,7 @@ Given `json`, a JSONPath string `paths`, and the JSON data
 the location exists, update the pre-existing value. Otherwise,
 create the necessary data structures needed to contain `value`.
 
-The following caveats apply:
-- If only the root \"$\" is provided, `json` is overwritten in
-  its entirety.
-- If an array index skips over any vector entries, those skipped
-  entries will be assigned nil.
-- If a path contains a wildcard and the location up to that
-  point does not exist, create a new vector.
-- If a path contains a wildcard and the location is a collection,
-  append it to the coll. In the case of maps, the key is its
-  current size, e.g. {\"2\" : \"foo\"}.
-- Recursive descent, array slicing, and negative array indices
-  are disallowed (as per strict mode).
-
-Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`. Also accepts the following args:
-
-:multi-value?     If provided, then `value` must be a collection of
-                  values that will be applied in order, e.g. for an
-                  array specified by `[0,1]` in the path, then the first
-                  and second elements of `value` will be applied. Returns
-                  the modified `json` once `value` or the available path
-                  seqs runs out.
-:wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs instead of overwriting existing
-                  values. Default `false`.
-:wildcard-limit   Dictates how many wildcard paths should be generated.
-                  If `multi-value?`, defaults to the number of values.
-                  In overwrite mode, defaults to the length of each coll.
-                  In append mode, defaults to 1.
+Supports :first? in `opts-map`; :strict? is always overridden to `true`. Also accepts :wildcard-append? and :wildcard-limit args to affect behavior on wildcards.
 ```
 
 ``` clojure
@@ -295,17 +261,8 @@ Otherwise, create the necessary data structures needed to contain `value`.
 For example, an array specified by `[0,1]` in the path, then the first
 and second elements of `value` will be applied. Returns the modified
 `json` once `value` or the available path seqs runs out.
-
-The same caveats as `apply-value` apply here as well.
    
-The following `opts-map` fields are supported:
-:first?           Apply only the first \"|\"-separated path. Default false.
-:strict?          Always overrides to true regardless of value provided.
-:wildcard-append? Dictates if wildcard values should be appended to
-                  the end of existing seqs instead of overwriting existing
-                  values. Default `false`.
-:wildcard-limit   Dictates how many wildcard paths should be generated.
-                  Defaults to the number of values.
+Supports :first? in `opts-map`; :strict? is always overridden to `true`. Also accepts :wildcard-append? and :wildcard-limit args to affect behavior on wildcards.
 ```
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ argument; common fields in `opts-map` include:
 - `:return-missing?` - Return paths and/or values at locations not found in the JSONPath object. Missing values are returned as `nil`. Default false.
 - `:return-duplicates?` - Return duplicate values from a JSONPath object. Default true.
 - `:prune-empty?` - Remove empty collections and values from a JSONPath object after having values excised. Default false.
+- `:wildcard-append?` Dictates if wildcard values should be appended to the end of existing seqs instead of overwriting existing values. Default true.
+- `:wildcard-limit?` Dictates how many wildcard paths should be generated. In overwrite mode, defaults to the length of each coll encountered. In append mode, the default depends on the function (either `1` or, for `apply-multi-value`, the number of values).
 
 Each function has two versions: a regular and a starred version. The regular versions accept JSONPath strings, while the starred versions accept parsed paths (which is useful in performance-critical situations). The starred versions do not accept `:first?` or `:strict?` as `opts-map` fields.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Supports :first?, :strict?, and :prune-empty? in `opts-map`.
    (excise stmt "$.id"))
 ```
 
-### apply-values
+### apply-value
 
 ```
 Given `json`, a JSONPath string `paths`, and the JSON data
@@ -208,8 +208,7 @@ The following caveats apply:
 - Recursive descent, array slicing, and negative array indices
   are disallowed (as per strict mode).
 
-Supports :first? in `opts-map`. :strict? is always overridden to
-`true`.
+Supports :first? and :multi-value? in `opts-map`. :strict? is always overridden to `true`.
 ```
 
 ``` clojure

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -505,7 +505,7 @@
                        seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs instead of overwriting existing
-                       values. Default `true`.
+                       values. Default `false`.
      :wildcard-limit   Dictates the max number of values to applied per coll.
                        If `multi-value?`, defaults to the number of values.
                        In overwrite mode, defaults to the length of each coll.
@@ -518,7 +518,7 @@
                  wildcard-append?
                  wildcard-limit]
           :or {multi-value?     false
-               wildcard-append? true}}
+               wildcard-append? false}}
          opts-map
          _
          (assert-multi-value multi-value? value)
@@ -572,7 +572,7 @@
                        seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs instead of overwriting existing
-                       values. Default `true`.
+                       values. Default `false`.
      :wildcard-limit   Dictates how many wildcard paths should be generated.
                        If `multi-value?`, defaults to the number of values.
                        In overwrite mode, defaults to the length of each coll.

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -204,15 +204,20 @@
    
    The following `opts-map` fields are supported:
      :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs. Default `true`.
-     :wildcard-limit`, Dicates how many wildcard paths should be generated.
-                       Default `1`."
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
+     :wildcard-limit   Dictates how many wildcard paths should be generated.
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1."
   ([json paths]
    (speculate-paths* json paths {}))
   ([json paths opts-map]
    (let [{:keys [wildcard-append? wildcard-limit]
-          :or {wildcard-append? true wildcard-limit 1}}
+          :or {wildcard-append? true}}
          opts-map
+         wildcard-limit
+         (or wildcard-limit
+             (and wildcard-append? 1))
          enum-paths
          (fn [path]
            (->> (json-path/speculative-path-seqs
@@ -234,9 +239,11 @@
      :first?           Only apply the first \"|\"-separated path.
      :strict?          Always set to `true`.
      :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs. Default `true`.
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
      :wildcard-limit   Dictates how many wildcard paths should be generated.
-                       Default `1`."
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1"
   ([json paths]
    (speculate-paths json paths {}))
   ([json paths opts-map]
@@ -479,9 +486,12 @@
                        the modified `json` once `value` or the available path
                        seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs. Default `true`.
-     :wildcard-limit`, Dicates how many wildcard paths should be generated.
-                       Default `1`."
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
+     :wildcard-limit   Dictates the max number of values to applied per coll.
+                       If `multi-value?`, defaults to the number of values.
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1."
   ([json paths value]
    (apply-value* json paths value {}))
   ([json paths value opts-map]
@@ -490,13 +500,19 @@
                  wildcard-append?
                  wildcard-limit]
           :or {multi-value?     false
-               wildcard-append? true
-               wildcard-limit   1}}
+               wildcard-append? true}}
          opts-map
+         wildcard-limit
+         (or wildcard-limit
+             (cond
+               multi-value?     (count value)
+               wildcard-append? 1
+               :else            nil))
          ;; Paths and values
          path-fn   (fn [path]
                      (json-path/speculative-path-seqs
-                      json path
+                      json
+                      path
                       :wildcard-append? wildcard-append?
                       :wildcard-limit wildcard-limit))
          paths*    (->> paths (map path-fn) (apply concat) (mapv :path))
@@ -536,9 +552,12 @@
                        the modified `json` once `value` or the available path
                        seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs. Default `true`.
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
      :wildcard-limit   Dictates how many wildcard paths should be generated.
-                       Default `1`."
+                       If `multi-value?`, defaults to the number of values.
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1."
   ([json paths value]
    (apply-value json paths value {}))
   ([json paths value opts-map]

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -408,12 +408,12 @@
    already-parsed JSONPaths.
    
    The following `opts-map` fields are supported:
-     :multi-value? If provided, then `value` must be a collection of
-                   values that will be applied in order, e.g. for an
-                   array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Returns
-                   the modified `json` once `value` or the available path
-                   seqs runs out.
+     :multi-value?     If provided, then `value` must be a collection of
+                       values that will be applied in order, e.g. for an
+                       array specified by `[0,1]` in the path, then the first
+                       and second elements of `value` will be applied. Returns
+                       the modified `json` once `value` or the available path
+                       seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs. Default `true`.
      :wildcard-limit`, Dicates how many wildcard paths should be generated.
@@ -466,14 +466,14 @@
      are disallowed (as per strict mode).
    
    The following `opts-map` fields are supported:
-     :first?       Apply only the first \"|\"-separated path. Default false.
-     :strict?      Always overrides to true regardless of value provided.
-     :multi-value? If provided, then `value` must be a collection of
-                   values that will be applied in order, e.g. for an
-                   array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Returns
-                   the modified `json` once `value` or the available path
-                   seqs runs out.
+     :first?           Apply only the first \"|\"-separated path. Default false.
+     :strict?          Always overrides to true regardless of value provided.
+     :multi-value?     If provided, then `value` must be a collection of
+                       values that will be applied in order, e.g. for an
+                       array specified by `[0,1]` in the path, then the first
+                       and second elements of `value` will be applied. Returns
+                       the modified `json` once `value` or the available path
+                       seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs. Default `true`.
      :wildcard-limit   Dictates how many wildcard paths should be generated.

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -270,7 +270,7 @@
           (reduce (fn [acc m] (merge acc m)) {})))))
 
 (defn get-path-value-map
-  "Given `json` nd a JSONPath string `paths`, return a map associating
+  "Given `json` and a JSONPath string `paths`, return a map associating
    JSON paths to JSON values. Does not return duplicates.
    
    The following `opts-map` fields are supported:
@@ -454,7 +454,7 @@
    
    The following `opts-map` fields are supported:
      :first?       Apply only the first \"|\"-separated path. Default false.
-     :strict?      If provided, always overrides to true.
+     :strict?      Always overrides to true regardless of value provided.
      :multi-value? If provided, then `value` must be a collection of
                    values that will be applied in order, e.g. for an
                    array specified by `[0,1]` in the path, then the first
@@ -462,6 +462,7 @@
                    potentially-infinite lazy seqs. Returns the modified
                    `json` once `value` or the available path seqs runs out."
   ([json paths value]
-   (apply-value* json (parse-paths paths {:strict? true}) value))
+   (apply-value json paths value {}))
   ([json paths value opts-map]
-   (apply-value* json (parse-paths paths (assoc opts-map :strict? true)) value)))
+   (let [opts-map* (assoc opts-map :strict? true)]
+     (apply-value* json (parse-paths paths opts-map*) value opts-map*))))

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -411,9 +411,9 @@
      :multi-value? If provided, then `value` must be a collection of
                    values that will be applied in order, e.g. for an
                    array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Supports
-                   potentially-infinite lazy seqs. Returns the modified
-                   `json` once `value` or the available path seqs runs out.
+                   and second elements of `value` will be applied. Returns
+                   the modified `json` once `value` or the available path
+                   seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs. Default `true`.
      :wildcard-limit`, Dicates how many wildcard paths should be generated.
@@ -471,9 +471,9 @@
      :multi-value? If provided, then `value` must be a collection of
                    values that will be applied in order, e.g. for an
                    array specified by `[0,1]` in the path, then the first
-                   and second elements of `value` will be applied. Supports
-                   potentially-infinite lazy seqs. Returns the modified
-                   `json` once `value` or the available path seqs runs out.
+                   and second elements of `value` will be applied. Returns
+                   the modified `json` once `value` or the available path
+                   seqs runs out.
      :wildcard-append? Dictates if wildcard values should be appended to
                        the end of existing seqs. Default `true`.
      :wildcard-limit   Dictates how many wildcard paths should be generated.

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -201,67 +201,6 @@
   ([json paths opts-map]
    (get-paths* json (parse-paths paths opts-map) opts-map)))
 
-;; Speculate Paths ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(s/fdef speculate-paths*
-  :args (s/cat :json ::json/json
-               :paths ::json-path/strict-paths
-               :opts-map (s/? (s/keys :opt-un [::wildcard-append?
-                                               ::wildcard-limit])))
-  :ret (s/every ::json/path))
-
-(defn speculate-paths*
-  "Like `speculate-paths`, but except that the `paths` argument is a
-   vector of already-parsed JSONPaths.
-   
-   The following `opts-map` fields are supported:
-     :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs instead of overwriting existing
-                       values. Default `true`.
-     :wildcard-limit   Dictates how many wildcard paths should be generated.
-                       In overwrite mode, defaults to the length of each coll.
-                       In append mode, defaults to 1."
-  ([json paths]
-   (speculate-paths* json paths {}))
-  ([json paths opts-map]
-   (let [{:keys [wildcard-append? wildcard-limit]
-          :or {wildcard-append? true}}
-         opts-map
-         wildcard-limit
-         (or wildcard-limit
-             (and wildcard-append? 1))
-         enum-paths
-         (fn [path]
-           (->> (json-path/speculative-path-seqs json
-                                                 path
-                                                 wildcard-append?
-                                                 wildcard-limit)
-                (mapv :path)))]
-     (->> paths (mapcat enum-paths) distinct vec))))
-
-(defn speculate-paths
-  "Given `json` and a JSONPath string `paths`, return a vector of
-   definite key paths, just like `get-paths`. However, unlike `get-paths`,
-   paths will be enumerated even if the corresponding value does not exist
-   in `json` on that path; in other words, it speculates what paths would
-   exist if they are applied. If the string contains multiple JSONPaths, we
-   return the key paths for all strings.
-   
-   The following `opts-map` fields are supported:
-     :first?           Only apply the first \"|\"-separated path.
-     :strict?          Always set to `true`.
-     :wildcard-append? Dictates if wildcard values should be appended to
-                       the end of existing seqs instead of overwriting existing
-                       values. Default `true`.
-     :wildcard-limit   Dictates how many wildcard paths should be generated.
-                       In overwrite mode, defaults to the length of each coll.
-                       In append mode, defaults to 1"
-  ([json paths]
-   (speculate-paths json paths {}))
-  ([json paths opts-map]
-   (let [opts-map* (assoc opts-map :strict? true)]
-     (speculate-paths* json (parse-paths paths opts-map*) opts-map*))))
-
 ;; Get Values ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Originally "get-at"
@@ -475,7 +414,68 @@
   ([json paths opts-map]
    (excise* json (parse-paths paths opts-map) opts-map)))
 
-;; Apply Value(s) ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Speculate Paths ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef speculate-paths*
+  :args (s/cat :json ::json/json
+               :paths ::json-path/strict-paths
+               :opts-map (s/? (s/keys :opt-un [::wildcard-append?
+                                               ::wildcard-limit])))
+  :ret (s/every ::json/path))
+
+(defn speculate-paths*
+  "Like `speculate-paths`, but except that the `paths` argument is a
+   vector of already-parsed JSONPaths.
+   
+   The following `opts-map` fields are supported:
+     :wildcard-append? Dictates if wildcard values should be appended to
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
+     :wildcard-limit   Dictates how many wildcard paths should be generated.
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1."
+  ([json paths]
+   (speculate-paths* json paths {}))
+  ([json paths opts-map]
+   (let [{:keys [wildcard-append? wildcard-limit]
+          :or {wildcard-append? true}}
+         opts-map
+         wildcard-limit
+         (or wildcard-limit
+             (and wildcard-append? 1))
+         enum-paths
+         (fn [path]
+           (->> (json-path/speculative-path-seqs json
+                                                 path
+                                                 wildcard-append?
+                                                 wildcard-limit)
+                (mapv :path)))]
+     (->> paths (mapcat enum-paths) distinct vec))))
+
+(defn speculate-paths
+  "Given `json` and a JSONPath string `paths`, return a vector of
+   definite key paths, just like `get-paths`. However, unlike `get-paths`,
+   paths will be enumerated even if the corresponding value does not exist
+   in `json` on that path; in other words, it speculates what paths would
+   exist if they are applied. If the string contains multiple JSONPaths, we
+   return the key paths for all strings.
+   
+   The following `opts-map` fields are supported:
+     :first?           Only apply the first \"|\"-separated path.
+     :strict?          Always set to `true`.
+     :wildcard-append? Dictates if wildcard values should be appended to
+                       the end of existing seqs instead of overwriting existing
+                       values. Default `true`.
+     :wildcard-limit   Dictates how many wildcard paths should be generated.
+                       In overwrite mode, defaults to the length of each coll.
+                       In append mode, defaults to 1"
+  ([json paths]
+   (speculate-paths json paths {}))
+  ([json paths opts-map]
+   (let [opts-map* (assoc opts-map :strict? true)]
+     (speculate-paths* json (parse-paths paths opts-map*) opts-map*))))
+
+;; Apply Value ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (s/fdef apply-value*
   :args (s/cat :json ::json/json
@@ -555,6 +555,8 @@
   ([json paths value opts-map]
    (let [opts-map* (assoc opts-map :strict? true)]
      (apply-value* json (parse-paths paths opts-map*) value opts-map*))))
+
+;; Apply Multiple Values ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (s/fdef apply-multi-value*
   :args (s/cat :json ::json/json

--- a/src/main/com/yetanalytics/pathetic.cljc
+++ b/src/main/com/yetanalytics/pathetic.cljc
@@ -501,11 +501,8 @@
                       :wildcard-limit wildcard-limit))
          paths*    (->> paths (map path-fn) (apply concat) (mapv :path))
          path-vals (if multi-value?
-                     (->> (interleave paths* value) ; [p v ...] => [[p v] ...]
-                          (apply assoc {})
-                          (into []))
-                     (->> paths*
-                          (mapv (fn [path] [path value]))))]
+                     (mapv (fn [p va] [p va]) paths* value)
+                     (mapv (fn [p] [p value]) paths*))]
      (reduce (fn [json [path v]] (json/jassoc-in json path v))
              json
              path-vals))))

--- a/src/main/com/yetanalytics/pathetic/json_path.cljc
+++ b/src/main/com/yetanalytics/pathetic/json_path.cljc
@@ -562,14 +562,7 @@
                           :rest (rest rst)
                           :path (conj pth (if (map? jsn) (str idx) idx))}))
                  (pop worklist)
-                 (range idx-start idx-end))
-                #_(conj (pop worklist)
-                      {:json nil
-                       :rest (rest rst)
-                       :path (conj pth (cond
-                                         (vector? jsn) (-> jsn count)
-                                         (map? jsn) (-> jsn count str)
-                                         :else 0))})]
+                 (range idx-start idx-end))]
             (recur worklist' reslist))
           :else ;; Includes recursive descent
           (throw (ex-info "Illegal path element"

--- a/src/main/com/yetanalytics/pathetic/json_path.cljc
+++ b/src/main/com/yetanalytics/pathetic/json_path.cljc
@@ -590,8 +590,9 @@
                                 wildcard-limit (take wildcard-limit))
                               (coll? jsn)
                               (range (or wildcard-limit
-                                         (count-safe jsn)))
-                              :else [0]))
+                                         (count jsn)))
+                              :else
+                              (range (or wildcard-limit 1))))
                 worklist' (reduce
                            (fn [worklist idx]
                              (conj worklist

--- a/src/main/com/yetanalytics/pathetic/json_path.cljc
+++ b/src/main/com/yetanalytics/pathetic/json_path.cljc
@@ -1,10 +1,11 @@
 (ns com.yetanalytics.pathetic.json-path
   (:require #?(:clj [clojure.core.match :as m]
                :cljs [cljs.core.match :as m])
-            [clojure.string     :as string]
-            [clojure.walk       :as w]
-            [clojure.spec.alpha :as s]
-            [instaparse.core    :as insta]
+            [clojure.string         :as string]
+            [clojure.walk           :as w]
+            [clojure.spec.alpha     :as s]
+            [clojure.spec.gen.alpha :as sgen]
+            [instaparse.core        :as insta]
             [com.yetanalytics.pathetic.json :as json]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -88,7 +89,9 @@
 ;; Strict versions of above
 
 (s/def ::strict-keyset
-  (s/every (s/or :key string? :index nat-int?)
+  (s/every (s/or :key string?
+                 ;; Need to limit generated index size
+                 :index (s/with-gen nat-int? #(sgen/choose 0 1000)))
            :type vector?
            :min-count 1
            :gen-max 5))
@@ -99,12 +102,22 @@
 
 (s/def ::strict-path
   (s/every ::strict-element
-           :type vector?))
+           :type vector?
+           ;; We need to limit gen here since too many wildcards can lead to
+           ;; exponential blowup (25^3 = 15,625)
+           :gen-max 3))
 
 (s/def ::strict-paths
   (s/every ::strict-path
            :type vector?
-           :min-count 1))
+           :min-count 1
+           :gen-max 5))
+
+(s/def ::wildcard-append?
+  boolean?)
+
+(s/def ::wildcard-limit ; Need `choose` to limit generated int size
+  (s/nilable (s/with-gen int? #(sgen/choose -5 25))))
 
 ;; Instaparse parsing failures
 
@@ -325,8 +338,15 @@
 
 ;; Helper functions
 
-(defn- count-safe [coll]
+(defn- count-safe
+  "Like `count` but returns 0 instead of throwing if `coll` is a scalar."
+  [coll]
   (if (coll? coll) (count coll) 0))
+
+(defn- get-safe
+  "Get a value only if `coll` is an actual coll (i.e. not a string)."
+  [coll k]
+  (when (coll? coll) (get coll k)))
 
 (defn- normalize-indices
   "Normalize indices by doing the following:
@@ -444,7 +464,7 @@
                    ;; nil values from non-existent ones in the coll.
                    (if (contains? jsn sub-elm)
                      [(conj worklist
-                            {:json (get jsn sub-elm)
+                            {:json (get-safe jsn sub-elm)
                              :rest (rest rst)
                              :path (conj pth sub-elm)
                              :desc false})
@@ -512,7 +532,9 @@
 
 (s/fdef speculative-path-seqs
   :args (s/cat :json ::json/json
-               :path ::strict-path)
+               :path ::strict-path
+               :wildcard-append? ::wildcard-append?
+               :wildcard-limit   ::wildcard-limit)
   :ret  (s/every (s/keys :req-un [::json/json ::json/path])
                  :kind vector?))
 
@@ -524,7 +546,10 @@
    Accepts two more args: `wildcard-append?`, which dictates if wildcard values
    should be appended to the end of existing seqs (default `true`), and
    `wildcard-limit`, dictating how many wildcard paths should be generated
-   (defaults to 1 in append mode, the coll size in overwrite mode)."
+   (defaults to 1 in append mode, the coll size in overwrite mode).
+   
+   Note that too many wildcards in `json-path`, or too large of a value of
+   `wildcard-limit`, may lead to exponential blowup."
   [json-obj json-path wildcard-append? wildcard-limit]
   (loop [worklist (init-queue {:json json-obj
                                :rest json-path
@@ -540,7 +565,7 @@
                  (fn [worklist sub-elm]
                    (if (or (string? sub-elm) (nat-int? sub-elm))
                      (conj worklist
-                           {:json (get jsn sub-elm)
+                           {:json (get-safe jsn sub-elm)
                             :rest (rest rst)
                             :path (conj pth sub-elm)})
                      (throw (ex-info "Illegal path element"

--- a/src/test/com/yetanalytics/pathetic/json_path_test.cljc
+++ b/src/test/com/yetanalytics/pathetic/json_path_test.cljc
@@ -187,8 +187,7 @@
                          json-path/parse
                          json-path/parse-first
                          json-path/path-seqs
-                         ;; Skip since generator can get quite slow
-                         #_json-path/speculative-path-seqs]
+                         json-path/speculative-path-seqs]
                        {:clojure.spec.test.check/opts
                         {:num-tests #?(:clj 100 :cljs 20)
                          :seed (rand-int 2000000000)}})

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -429,14 +429,6 @@
            (p/excise long-statement
                      "$.context.contextActivities.grouping[*]")))))
 
-(comment
-  (p/apply-value {"universe" [{"foo" 0} {"bar" 1}]}
-                 "$.universe.*"
-                 [{"baz" 2} {"qux" 3}]
-                 {:multi-value? true
-                  :wildcard-append? false
-                  :wildcard-limit 3}))
-
 (deftest apply-value-test
   (testing "Applying and updating values using JSONPath"
     (is (= {"foo" 0}

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -138,6 +138,16 @@
                               "$.universe.*.foo.bar"
                               {:wildcard-append? false
                                :wildcard-limit   1})))
+    (is (= []
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false
+                               :wildcard-limit   -1})))
+    (is (= []
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? true
+                               :wildcard-limit   -1})))
     (is (= (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
                               "$.universe[0].foo.bar")
            (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
@@ -611,9 +621,8 @@
                          p/get-path-value-map*
                          p/select-keys-at*
                          p/excise*
-                         ;; Don't check apply-value* since the generator often
-                         ;; gets stuck.
-                         #_p/apply-value*]
+                         p/speculate-paths*
+                         p/apply-value*]
                        {:clojure.spec.test.check/opts
                         {:num-tests #?(:clj 200 :cljs 40)
                          :seed (rand-int 2000000000)}})

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -107,75 +107,6 @@
            (p/get-paths long-statement
                         "$.context.contextActivities.category[*].id")))))
 
-(deftest speculate-paths-test
-  (testing "Enumerate deterministic JSONPaths regardless of values present"
-    (is (= [["foo"]]
-           (p/speculate-paths nil "$.foo")))
-    (is (= [[0]]
-           (p/speculate-paths [] "$[0]")))
-    (is (= [["universe" 2 "foo" "bar"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar")))
-    (is (= [["universe" 2 "foo" "bar"]
-            ["universe" 3 "foo" "bar"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-limit 2})))
-    (is (= [["universe" 0 "foo" "bar"]
-            ["universe" 1 "foo" "bar"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-append? false})))
-    (is (= [["universe" 0 "foo" "bar"]
-            ["universe" 1 "foo" "bar"]
-            ["universe" 2 "foo" "bar"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-append? false
-                               :wildcard-limit   3})))
-    (is (= [["universe" 0 "foo" "bar"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-append? false
-                               :wildcard-limit   1})))
-    (is (= []
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-append? false
-                               :wildcard-limit   -1})))
-    (is (= []
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe.*.foo.bar"
-                              {:wildcard-append? true
-                               :wildcard-limit   -1})))
-    (is (= (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe[0].foo.bar")
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe[0].foo.bar | $.universe[1].baz"
-                              {:first? true})))
-    (is (= [["universe" 0 "foo" "bar"]
-            ["universe" 1 "baz"]]
-           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
-                              "$.universe[0].foo.bar | $.universe[1].baz")))
-    (is (= [["store" "book" 4 "author"]]
-           (p/speculate-paths goessner-ex "$.store.book[*].author")))
-    (is (= [["store" "book" 4 "isbn"]]
-           (p/speculate-paths goessner-ex "$.store.book[*].isbn")))
-    (is (= [["context" "contextActivities" "grouping" 0]]
-           (p/speculate-paths long-statement
-                              "$.context.contextActivities.grouping[*]")))
-    (is (= [["context" "contextActivities" "grouping" 0]]
-           (p/speculate-paths long-statement
-                              "$.context.contextActivities.grouping[0]")))
-    (is (= [["context" "contextActivities" "grouping" 0 "id"]]
-           (p/speculate-paths long-statement
-                              "$.context.contextActivities.grouping[*].id")))
-    (is (= [["context" "contextActivities" "category" 1 "id"]]
-           (p/speculate-paths long-statement
-                              "$.context.contextActivities.category[*].id")))
-    (is (strict-parse-failed?
-         (p/get-paths goessner-ex "$.store.bicycle..*")))))
-
 (deftest get-values-test-1
   (testing "Testing JSONPath on example provided by Goessner"
     (are [expected path]
@@ -498,10 +429,74 @@
            (p/excise long-statement
                      "$.context.contextActivities.grouping[*]")))))
 
-(comment
-  (p/apply-value {"universe" [{"foo" 0} {"bar" 1}]}
-                 "$.universe[1].*"
-                 2))
+(deftest speculate-paths-test
+  (testing "Enumerate deterministic JSONPaths regardless of values present"
+    (is (= [["foo"]]
+           (p/speculate-paths nil "$.foo")))
+    (is (= [[0]]
+           (p/speculate-paths [] "$[0]")))
+    (is (= [["universe" 2 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar")))
+    (is (= [["universe" 2 "foo" "bar"]
+            ["universe" 3 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-limit 2})))
+    (is (= [["universe" 0 "foo" "bar"]
+            ["universe" 1 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false})))
+    (is (= [["universe" 0 "foo" "bar"]
+            ["universe" 1 "foo" "bar"]
+            ["universe" 2 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false
+                               :wildcard-limit   3})))
+    (is (= [["universe" 0 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false
+                               :wildcard-limit   1})))
+    (is (= []
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false
+                               :wildcard-limit   -1})))
+    (is (= []
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? true
+                               :wildcard-limit   -1})))
+    (is (= (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar")
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar | $.universe[1].baz"
+                              {:first? true})))
+    (is (= [["universe" 0 "foo" "bar"]
+            ["universe" 1 "baz"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar | $.universe[1].baz")))
+    (is (= [["store" "book" 4 "author"]]
+           (p/speculate-paths goessner-ex "$.store.book[*].author")))
+    (is (= [["store" "book" 4 "isbn"]]
+           (p/speculate-paths goessner-ex "$.store.book[*].isbn")))
+    (is (= [["context" "contextActivities" "grouping" 0]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[*]")))
+    (is (= [["context" "contextActivities" "grouping" 0]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[0]")))
+    (is (= [["context" "contextActivities" "grouping" 0 "id"]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[*].id")))
+    (is (= [["context" "contextActivities" "category" 1 "id"]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.category[*].id")))
+    (is (strict-parse-failed?
+         (p/get-paths goessner-ex "$.store.bicycle..*")))))
 
 (deftest apply-value-test
   (testing "Applying and updating values using JSONPath"

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -429,6 +429,14 @@
            (p/excise long-statement
                      "$.context.contextActivities.grouping[*]")))))
 
+(comment
+  (p/apply-value {"universe" [{"foo" 0} {"bar" 1}]}
+                 "$.universe.*"
+                 [{"baz" 2} {"qux" 3}]
+                 {:multi-value? true
+                  :wildcard-append? false
+                  :wildcard-limit 3}))
+
 (deftest apply-value-test
   (testing "Applying and updating values using JSONPath"
     (is (= {"foo" 0}
@@ -481,12 +489,37 @@
       {"foo" [1]}       "$.foo[0]"
       {"foo" [nil 1]}   "$.foo[1]"
       {"foo" 1 "bar" 2} "$['foo','bar']"
-      {"foo" [1]}       "$.foo[*]" ; FIXME
+      {"foo" [1]}       "$.foo[*]"
       [1 2]             "$[0,1]"
       1                 "$"
       {"foo" 2}         "$ | $.foo"
-      {"foo" [2]}       "$ | $.foo[0,1]" ; FIXME
-      )))
+      {"foo" [2]}       "$ | $.foo[0,1]"))
+  (testing "Applying w/ different values of `:wildcard-append?` and `:wildcard-limit`"
+    (is (= {"foo" [1]}
+           (p/apply-value {"foo" []} "$.foo.*" [1 2] {:multi-value? true})))
+    (is (= {"foo" [1 2]}
+           (p/apply-value {"foo" []} "$.foo.*" [1 2] {:multi-value? true
+                                                      :wildcard-limit 2})))
+    (is (= {"foo" [1 2]}
+           (p/apply-value {"foo" []} "$.foo.*" [1 2] {:multi-value? true
+                                                      :wildcard-limit 3})))
+    (is (= {"foo" [0 1]}
+           (p/apply-value {"foo" [0]} "$.foo.*" [1] {:multi-value? true
+                                                     :wildcard-append? true})))
+    (is (= {"foo" [1]}
+           (p/apply-value {"foo" [0]} "$.foo.*" [1] {:multi-value? true
+                                                     :wildcard-append? false})))
+    (is (= {"foo" [1]}
+           (p/apply-value {"foo" [0]} "$.foo.*" [1 2] {:multi-value? true
+                                                       :wildcard-append? false})))
+    (is (= {"foo" [0 1 2]}
+           (p/apply-value {"foo" [0]} "$.foo.*" [1 2] {:multi-value? true
+                                                       :wildcard-append? true
+                                                       :wildcard-limit 2})))
+    (is (= {"foo" [1 2]}
+           (p/apply-value {"foo" [0]} "$.foo.*" [1 2] {:multi-value? true
+                                                       :wildcard-append? false
+                                                       :wildcard-limit 2})))))
 
 (deftest gen-tests
   (testing "Generative tests for pathetic"

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -637,6 +637,10 @@
                                      :wildcard-limit   2}
       {"foo" [1 0 0]}     [1 2]     {:wildcard-append? false
                                      :wildcard-limit   1}
+      {"foo" [0 0 0]}     [1 2]     {:wildcard-append? false
+                                     :wildcard-limit   0}
+      {"foo" [0 0 0]}     [1 2]     {:wildcard-append? false
+                                     :wildcard-limit   -1}
       {"foo" [0 0 0 1 2]} [1 2]     {:wildcard-append? true}
       {"foo" [0 0 0 1 2]} [1 2]     {:wildcard-append? true
                                      :wildcard-limit   3}
@@ -645,7 +649,36 @@
       {"foo" [0 0 0 1]}   [1 2]     {:wildcard-append? true
                                      :wildcard-limit   1}
       {"foo" [0 0 0]}     [1 2]     {:wildcard-append? true
-                                     :wildcard-limit   0})))
+                                     :wildcard-limit   0}
+      {"foo" [0 0 0]}     [1 2]     {:wildcard-append? true
+                                     :wildcard-limit   -1})
+    (are [expected values opt-args]
+         (= expected
+            (p/apply-multi-value {"foo" 0} "$.foo.*" values opt-args))
+      {"foo" [1 2]}   [1 2]   {}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? false}
+      {"foo" [1 2 3]} [1 2 3] {:wildcard-append? false}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? false
+                               :wildcard-limit   3}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? false
+                               :wildcard-limit   2}
+      {"foo" [1]}     [1 2]   {:wildcard-append? false
+                               :wildcard-limit   1}
+      {"foo" 0}       [1 2]   {:wildcard-append? false
+                               :wildcard-limit   0}
+      {"foo" 0}       [1 2]   {:wildcard-append? false
+                               :wildcard-limit   -1}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? true}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? true
+                               :wildcard-limit   3}
+      {"foo" [1 2]}   [1 2]   {:wildcard-append? true
+                               :wildcard-limit   2}
+      {"foo" [1]}     [1 2]   {:wildcard-append? true
+                               :wildcard-limit   1}
+      {"foo" 0}       [1 2]   {:wildcard-append? true
+                               :wildcard-limit   0}
+      {"foo" 0}       [1 2]   {:wildcard-append? true
+                               :wildcard-limit   -1})))
 
 (deftest gen-tests
   (testing "Generative tests for pathetic"

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -521,6 +521,14 @@
   (testing "Applying and updating multiple values"
     (is (= {"foo" []} ; unchanged
            (p/apply-value {"foo" []} "$.foo.*" [] {:multi-value? true})))
+    (is (= {"foo" []}
+           (p/apply-value {"foo" []} "$.foo[0]" [] {:multi-value? true})))
+    (is (= {"foo" []}
+           (p/apply-value {"foo" []} "$.foo[0,1]" [] {:multi-value? true})))
+    (is (= {"foo" [1]}
+           (p/apply-value {"foo" []} "$.foo[0]" [1] {:multi-value? true})))
+    (is (= {"foo" [1]}
+           (p/apply-value {"foo" []} "$.foo[0,1]" [1] {:multi-value? true})))
     (are [expected path]
          (= expected
             (p/apply-value {"foo" []} path [1 2] {:multi-value? true}))

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -470,7 +470,23 @@
                (p/apply-value "$.context.contextActivities.category[*].id"
                               "http://www.example.com/meetings/categories/brainstorm_sesh")
                (p/apply-value "$.context.contextActivities.category[*].id"
-                              "http://www.example.com/meetings/categories/whiteboard_sesh"))))))
+                              "http://www.example.com/meetings/categories/whiteboard_sesh")))))
+  (testing "Applying and updating multiple values"
+    (are [expected path]
+         (= expected
+            (p/apply-value {"foo" []} path [1 2] {:multi-value? true}))
+      {"foo" [1 2]}     "$.foo[0,1]"
+      {"foo" [nil 1 2]} "$.foo[1,2]"
+      {"foo" [1 nil 2]} "$.foo[0,2]"
+      {"foo" [1]}       "$.foo[0]"
+      {"foo" [nil 1]}   "$.foo[1]"
+      {"foo" 1 "bar" 2} "$['foo','bar']"
+      {"foo" [1]}       "$.foo[*]" ; FIXME
+      [1 2]             "$[0,1]"
+      1                 "$"
+      {"foo" 2}         "$ | $.foo"
+      {"foo" [2]}       "$ | $.foo[0,1]" ; FIXME
+      )))
 
 (deftest gen-tests
   (testing "Generative tests for pathetic"

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -107,6 +107,53 @@
            (p/get-paths long-statement
                         "$.context.contextActivities.category[*].id")))))
 
+(deftest speculate-paths-test
+  (testing "Enumerate deterministic JSONPaths regardless of values present"
+    (is (= [["foo"]]
+           (p/speculate-paths nil "$.foo")))
+    (is (= [[0]]
+           (p/speculate-paths [] "$[0]")))
+    (is (= [["universe" 2 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar")))
+    (is (= [["universe" 0 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false})))
+    (is (= [["universe" 0 "foo" "bar"]
+            ["universe" 1 "foo" "bar"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe.*.foo.bar"
+                              {:wildcard-append? false
+                               :wildcard-limit   2})))
+    (is (= (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar")
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar | $.universe[1].baz"
+                              {:first? true})))
+    (is (= [["universe" 0 "foo" "bar"]
+            ["universe" 1 "baz"]]
+           (p/speculate-paths {"universe" [{"foo" {"bar" 0}} {"baz" 1}]}
+                              "$.universe[0].foo.bar | $.universe[1].baz")))
+    (is (= [["store" "book" 4 "author"]]
+           (p/speculate-paths goessner-ex "$.store.book[*].author")))
+    (is (= [["store" "book" 4 "isbn"]]
+           (p/speculate-paths goessner-ex "$.store.book[*].isbn")))
+    (is (= [["context" "contextActivities" "grouping" 0]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[*]")))
+    (is (= [["context" "contextActivities" "grouping" 0]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[0]")))
+    (is (= [["context" "contextActivities" "grouping" 0 "id"]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.grouping[*].id")))
+    (is (= [["context" "contextActivities" "category" 1 "id"]]
+           (p/speculate-paths long-statement
+                              "$.context.contextActivities.category[*].id")))
+    (is (strict-parse-failed?
+         (p/get-paths goessner-ex "$.store.bicycle..*")))))
+
 (deftest get-values-test-1
   (testing "Testing JSONPath on example provided by Goessner"
     (are [expected path]

--- a/src/test/com/yetanalytics/pathetic_test.cljc
+++ b/src/test/com/yetanalytics/pathetic_test.cljc
@@ -519,6 +519,8 @@
                (p/apply-value "$.context.contextActivities.category[*].id"
                               "http://www.example.com/meetings/categories/whiteboard_sesh")))))
   (testing "Applying and updating multiple values"
+    (is (= {"foo" []} ; unchanged
+           (p/apply-value {"foo" []} "$.foo.*" [] {:multi-value? true})))
     (are [expected path]
          (= expected
             (p/apply-value {"foo" []} path [1 2] {:multi-value? true}))


### PR DESCRIPTION
Update `apply-value` to support the following opt map arguments, in a general effort to let it support multiple values (again):
- `:wildcard-append?`: Dictates if wildcard values should be appended to the end of existing seqs. Default `true`.
- `:wildcard-limit`: Dictates how many wildcard paths should be generated. Default `1

Add a `apply-multi-value` that is similar to `apply-value` except it works on a collection of multiple values. Also add a `speculate-paths` function that accepts `:wildcard-append?` and `:wildcard-limit`.

**Questions:**
- ~Should wildcard override mode be the default? Right now append mode is the default, so changing this would necessitate a break version.~ **Yes**
- ~In wildcard override mode, should _all_ elements of an array be overridden even if the array has more elements than `:wildcard-limit`?~ **Yes, and change `:wildcard-limit` behavior accordignly**